### PR TITLE
Bug: tag-select no-multiple return value

### DIFF
--- a/uu5g04/src/forms/tag-select.js
+++ b/uu5g04/src/forms/tag-select.js
@@ -219,6 +219,14 @@ export const TagSelect = Context.withContext(
         setStateCallback
       );
     },
+
+    getValue_() {
+      if (this.props.multiple) {
+        return this.state.value;
+      }
+
+      return this.state.value[0];
+    },
     //@@viewOff:overriding
 
     //@@viewOn:private


### PR DESCRIPTION
Originally it returns array even when it has props multiple=false, now it decide to return array or value.